### PR TITLE
feat: add toy robot app

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,36 @@
+import { createInterface } from "readline";
+import { introductionMessage } from "../messages";
+import { commandRobot } from "../robot/command-robot";
+import { AppState } from "../types";
+import { defaultTabletopBoundary } from "../variables";
+import { parseCommand } from "./utils";
+
+export const runRobotApp = (): void => {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  let robot: AppState["robot"] = null;
+  const tabletopBoundary: AppState["tabletopBoundary"] = defaultTabletopBoundary;
+
+  const initializeApp = () => {
+    console.log(introductionMessage);
+    rl.prompt();
+  };
+
+  initializeApp();
+
+  rl.on("line", (line: string) => {
+    try {
+      const action = parseCommand(line);
+
+      robot = commandRobot(robot, action, tabletopBoundary);
+
+      rl.prompt();
+    } catch (error) {
+      console.error(error);
+      rl.prompt();
+    }
+  });
+};

--- a/src/cli/utils/__tests__/normalize-input.test.ts
+++ b/src/cli/utils/__tests__/normalize-input.test.ts
@@ -1,0 +1,15 @@
+import { normalizeInput } from "../normalize-input";
+
+describe("normalizeInput", () => {
+  it("converts string to upper case", () => {
+    const mockString = "you are awesome";
+
+    expect(normalizeInput(mockString)).toEqual("YOU ARE AWESOME");
+  });
+
+  it("trims white space of both ends of a string", () => {
+    const mockString = "   HELLO WORLD   ";
+
+    expect(normalizeInput(mockString)).toEqual("HELLO WORLD");
+  });
+});

--- a/src/cli/utils/__tests__/parse-command.test.ts
+++ b/src/cli/utils/__tests__/parse-command.test.ts
@@ -1,0 +1,81 @@
+import { invalidCommandErrorMessage } from "../../../messages";
+import { parseCommand } from "../parse-command";
+
+describe("parseCommand", () => {
+  it("throws an error for invalid command strings", () => {
+    const mockInput = "DANCE";
+    const invalidPlaceInput = "PLACE1,2,NORTH";
+
+    expect(() => {
+      parseCommand(mockInput);
+    }).toThrow(invalidCommandErrorMessage);
+
+    expect(() => {
+      parseCommand(invalidPlaceInput);
+    }).toThrow(invalidCommandErrorMessage);
+  });
+
+  it("returns the correct robot action object for a valid place command", () => {
+    const validInput = "PLACE 13,5,EAST";
+    const messyValidInput = "   pLaCE 13,5,EaST  ";
+
+    const expectedAction = {
+      type: "PLACE",
+      data: {
+        coordinates: [13, 5],
+        direction: "EAST",
+      },
+    };
+
+    expect(parseCommand(validInput)).toEqual(expectedAction);
+    expect(parseCommand(messyValidInput)).toEqual(expectedAction);
+  });
+
+  it("returns the correct robot action object for a valid move command", () => {
+    expect(parseCommand("MOVE")).toEqual({ type: "MOVE" });
+  });
+
+  it("returns the correct robot action object for a valid left command", () => {
+    expect(parseCommand("LEFT")).toEqual({ type: "LEFT" });
+  });
+
+  it("returns the correct robot action object for a valid right command", () => {
+    expect(parseCommand("RIGHT")).toEqual({ type: "RIGHT" });
+  });
+
+  it("returns the correct robot action object for a valid report command", () => {
+    expect(parseCommand("REPORT")).toEqual({ type: "REPORT" });
+  });
+
+  it("ignores additional arguments when not used by commands", () => {
+    const mockPlaceInput = "PLACE 2,3,WEST MELBOURNE";
+    const mockMoveInput = "MOVE 9000";
+    const mockLeftInput = "LEFT ON YOUR LEFT";
+    const mockRightInput = "RIGHT ON RIGHT ON RIGHT ON";
+    const mockReportInput = "REPORT --impostor";
+
+    expect(parseCommand(mockPlaceInput)).toEqual({
+      type: "PLACE",
+      data: {
+        coordinates: [2, 3],
+        direction: "WEST",
+      },
+    });
+
+    expect(parseCommand(mockMoveInput)).toEqual({
+      type: "MOVE",
+    });
+
+    expect(parseCommand(mockLeftInput)).toEqual({
+      type: "LEFT",
+    });
+
+    expect(parseCommand(mockRightInput)).toEqual({
+      type: "RIGHT",
+    });
+
+    expect(parseCommand(mockReportInput)).toEqual({
+      type: "REPORT",
+    });
+  });
+});

--- a/src/cli/utils/__tests__/parse-place-command-arguments.test.ts
+++ b/src/cli/utils/__tests__/parse-place-command-arguments.test.ts
@@ -1,0 +1,49 @@
+import { invalidPlaceArgumentMessage } from "../../../messages";
+import { parsePlaceCommandArguments } from "../parse-place-command-arguments";
+
+describe("parsePlaceCommandArguments", () => {
+  it("throws an error when the argument string has invalid coordinates", () => {
+    const negativeCoordinateString = "1,-1,NORTH";
+    const zeroLeadingCoordinateString = "02,1,SOUTH";
+    const nonNumberCoordinateString = "a,3,EAST";
+
+    expect(() => {
+      parsePlaceCommandArguments(negativeCoordinateString);
+    }).toThrow(invalidPlaceArgumentMessage);
+
+    expect(() => {
+      parsePlaceCommandArguments(zeroLeadingCoordinateString);
+    }).toThrow(invalidPlaceArgumentMessage);
+
+    expect(() => {
+      parsePlaceCommandArguments(nonNumberCoordinateString);
+    }).toThrow(invalidPlaceArgumentMessage);
+  });
+
+  it("throws an error when the argument string has an invalid direction", () => {
+    const mockString = "1,1,BLORTH";
+
+    expect(() => {
+      parsePlaceCommandArguments(mockString);
+    }).toThrow(invalidPlaceArgumentMessage);
+  });
+
+  it("throws an error when the argument string includes invalid characters", () => {
+    const mockString = "1,1,NORTHERN";
+    const excessWhiteSpaceString = "a, 3, EAST";
+
+    expect(() => {
+      parsePlaceCommandArguments(mockString);
+    }).toThrow(invalidPlaceArgumentMessage);
+
+    expect(() => {
+      parsePlaceCommandArguments(excessWhiteSpaceString);
+    }).toThrow(invalidPlaceArgumentMessage);
+  });
+
+  it("returns arguments as an array if the argument string is valid", () => {
+    const mockString = "3,5,WEST";
+
+    expect(parsePlaceCommandArguments(mockString)).toEqual([3, 5, "WEST"]);
+  });
+});

--- a/src/cli/utils/index.ts
+++ b/src/cli/utils/index.ts
@@ -1,0 +1,1 @@
+export { parseCommand } from "./parse-command";

--- a/src/cli/utils/normalize-input.ts
+++ b/src/cli/utils/normalize-input.ts
@@ -1,0 +1,2 @@
+export const normalizeInput = (input: string): string =>
+  input.trim().toUpperCase();

--- a/src/cli/utils/parse-command.ts
+++ b/src/cli/utils/parse-command.ts
@@ -1,0 +1,37 @@
+import { invalidCommandErrorMessage } from "../../messages";
+import { Command, CommandAction } from "../../types";
+import { normalizeInput } from "./normalize-input";
+import { parsePlaceCommandArguments } from "./parse-place-command-arguments";
+
+/**
+ * @param input - takes raw command line string
+ * @returns CommandAction data object to apply to the robot.
+ */
+export const parseCommand = (input: string): CommandAction | never => {
+  const normalizedInput = normalizeInput(input);
+  const [command, ...args] = normalizedInput.split(" ");
+
+  switch (command) {
+    case Command.Place: {
+      const [x, y, direction] = parsePlaceCommandArguments(args[0]);
+      return {
+        type: command,
+        data: {
+          coordinates: [x, y],
+          direction,
+        },
+      };
+    }
+    case Command.Move:
+    case Command.Left:
+    case Command.Right:
+    case Command.Report: {
+      return {
+        type: command,
+      };
+    }
+    default: {
+      throw Error(invalidCommandErrorMessage);
+    }
+  }
+};

--- a/src/cli/utils/parse-place-command-arguments.ts
+++ b/src/cli/utils/parse-place-command-arguments.ts
@@ -1,0 +1,20 @@
+import { invalidPlaceArgumentMessage } from "../../messages";
+import { Direction, XYCoordinates } from "../../types";
+
+const validPlaceArgumentsRegex = /^[1-9]\d*,[1-9]\d*,(NORTH|SOUTH|EAST|WEST)$/;
+
+/**
+ * @param input - raw input string of arguments for the pace command
+ * @returns formatted place command arguments in an array
+ */
+export const parsePlaceCommandArguments = (
+  argumentsString: string
+): [...XYCoordinates, Direction] | never => {
+  const isArgumentsValid = validPlaceArgumentsRegex.test(argumentsString);
+
+  if (!isArgumentsValid) throw Error(invalidPlaceArgumentMessage);
+
+  const [x, y, direction] = argumentsString.split(",");
+
+  return [parseInt(x), parseInt(y), direction as Direction];
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,0 @@
-describe("test", () => {
-  test("add", async () => {
-    expect(1 + 1).toEqual(2);
-  });
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-console.log("Hello World");
+import { runRobotApp } from "./cli";
+
+runRobotApp();

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,46 @@
+import { RobotState, XYCoordinates } from "./types";
+import { clockwiseDirections } from "./variables";
+
+export const validCommandsMessage = `Valid commands:
+PLACE X,Y,F (e.g. PLACE 1,2,EAST)
+MOVE
+LEFT
+RIGHT
+REPORT`;
+
+export const introductionMessage = `Hi! Welcome to my toy robot CLI app.
+To start, place the robot on the tabletop.
+
+${validCommandsMessage}`;
+
+export const getTabletopBoundaryMessage = (boundary: XYCoordinates): string => {
+  const [x, y] = boundary;
+  return `Tabletop dimensions: ${x}x${y}`;
+};
+
+export const getOutsideTabletopErrorMessage = (
+  boundary: XYCoordinates
+): string => `You can’t place or move the robot beyond the table.
+${getTabletopBoundaryMessage(boundary)}
+`;
+
+export const getReportRobotMessage = ({
+  coordinates,
+  direction,
+}: RobotState): string => {
+  const [x, y] = coordinates;
+  return `Output: ${x},${y},${direction}`;
+};
+
+export const invalidCommandErrorMessage = `Unrecognized command.
+
+${validCommandsMessage}`;
+
+export const robotNotPlacedErrorMessage = `Robot must first be placed on tabletop.
+Use command PLACE X,Y,F (e.g. PLACE 1,2,EAST)`;
+
+export const invalidPlaceArgumentMessage = `Invalid PLACE argument format.
+Follow the format: PLACE 2,3,NORTH`;
+
+export const invalidDirectionErrorMessage = `The direction is not valid.
+Directions can either be: ${clockwiseDirections.join(", ")}.`;

--- a/src/robot/__tests__/command-robot.test.ts
+++ b/src/robot/__tests__/command-robot.test.ts
@@ -1,0 +1,72 @@
+import {
+  AppState,
+  Command,
+  Direction,
+  OtherCommandAction,
+  PlaceCommandAction,
+  TurnCommandAction,
+} from "../../types";
+import { moveRobot, placeRobot, reportRobot, turnRobot } from "../actions";
+import { commandRobot } from "../command-robot";
+
+jest.mock("../actions", () => ({
+  placeRobot: jest.fn(),
+  turnRobot: jest.fn(),
+  moveRobot: jest.fn(),
+  reportRobot: jest.fn(),
+}));
+
+describe("commandRobot", () => {
+  const robot: AppState["robot"] = null;
+  const tabletopBoundary: AppState["tabletopBoundary"] = [100, 200];
+
+  it("runs the placeRobot command if the action type is PLACE", () => {
+    const mockAction: PlaceCommandAction = {
+      type: Command.Place,
+      data: {
+        coordinates: [80, 80],
+        direction: Direction.East,
+      },
+    };
+    commandRobot(robot, mockAction, tabletopBoundary);
+    expect(placeRobot).toHaveBeenCalledWith(
+      robot,
+      mockAction,
+      tabletopBoundary
+    );
+  });
+
+  it("runs the turnRobot command if the action type is LEFT or RIGHT", () => {
+    const leftAction: TurnCommandAction = {
+      type: Command.Left,
+    };
+    commandRobot(robot, leftAction, tabletopBoundary);
+
+    expect(turnRobot).toHaveBeenCalledWith(robot, leftAction);
+
+    const rightAction: TurnCommandAction = {
+      type: Command.Right,
+    };
+    commandRobot(robot, rightAction, tabletopBoundary);
+
+    expect(turnRobot).toHaveBeenCalledWith(robot, rightAction);
+  });
+
+  it("runs the moveRobot command if the action type is MOVE", () => {
+    const moveAction: OtherCommandAction = {
+      type: Command.Move,
+    };
+    commandRobot(robot, moveAction, tabletopBoundary);
+
+    expect(moveRobot).toHaveBeenCalledWith(robot, tabletopBoundary);
+  });
+
+  it("runs the reportRobot command if the action type is REPORT", () => {
+    const reportAction: OtherCommandAction = {
+      type: Command.Report,
+    };
+    commandRobot(robot, reportAction, tabletopBoundary);
+
+    expect(reportRobot).toHaveBeenCalledWith(robot);
+  });
+});

--- a/src/robot/actions/__tests__/move-robot.test.ts
+++ b/src/robot/actions/__tests__/move-robot.test.ts
@@ -1,0 +1,82 @@
+import {
+  getOutsideTabletopErrorMessage,
+  robotNotPlacedErrorMessage,
+} from "../../../messages";
+import { Direction, RobotState, XYCoordinates } from "../../../types";
+import { moveRobot } from "../move-robot";
+
+describe("moveRobot", () => {
+  const mockTabletopBoundary: XYCoordinates = [100, 200];
+
+  it("returns a robot state with new coordinates based on the direction the robot is facing", () => {
+    const mockRobotStateEast: RobotState = {
+      coordinates: [50, 0],
+      direction: Direction.East,
+    };
+
+    const newRobotStateEast: RobotState = {
+      ...mockRobotStateEast,
+      coordinates: [51, 0],
+    };
+
+    expect(moveRobot(mockRobotStateEast, mockTabletopBoundary)).toEqual(
+      newRobotStateEast
+    );
+
+    const mockRobotStateNorth: RobotState = {
+      coordinates: [20, 20],
+      direction: Direction.North,
+    };
+
+    const newRobotStateNorth: RobotState = {
+      ...mockRobotStateNorth,
+      coordinates: [20, 21],
+    };
+
+    expect(moveRobot(mockRobotStateNorth, mockTabletopBoundary)).toEqual(
+      newRobotStateNorth
+    );
+  });
+
+  it("allows overriding the robot's default number of steps taken per move", () => {
+    const mockRobotStateEast: RobotState = {
+      coordinates: [50, 0],
+      direction: Direction.East,
+    };
+
+    const newRobotStateEast: RobotState = {
+      ...mockRobotStateEast,
+      coordinates: [55, 0],
+    };
+
+    expect(moveRobot(mockRobotStateEast, mockTabletopBoundary, 5)).toEqual(
+      newRobotStateEast
+    );
+  });
+
+  it("throws an error if robot is not initialized (i.e. placed on tabletop) before moving", () => {
+    const mockRobotState = null;
+
+    expect(() => {
+      moveRobot(mockRobotState, mockTabletopBoundary);
+    }).toThrow(robotNotPlacedErrorMessage);
+  });
+
+  it("throws an error if moveRobot would move robot outside tabletop", () => {
+    const mockRobotStateSouth: RobotState = {
+      coordinates: [50, 0],
+      direction: Direction.South,
+    };
+    expect(() => {
+      moveRobot(mockRobotStateSouth, mockTabletopBoundary);
+    }).toThrow(getOutsideTabletopErrorMessage(mockTabletopBoundary));
+
+    const mockRobotStateEast: RobotState = {
+      coordinates: [100, 20],
+      direction: Direction.East,
+    };
+    expect(() => {
+      moveRobot(mockRobotStateEast, mockTabletopBoundary);
+    }).toThrow(getOutsideTabletopErrorMessage(mockTabletopBoundary));
+  });
+});

--- a/src/robot/actions/__tests__/place-robot.test.ts
+++ b/src/robot/actions/__tests__/place-robot.test.ts
@@ -1,0 +1,67 @@
+import { getOutsideTabletopErrorMessage } from "../../../messages";
+import {
+  Command,
+  Direction,
+  PlaceCommandAction,
+  RobotState,
+  XYCoordinates,
+} from "../../../types";
+import { placeRobot } from "../place-robot";
+
+describe("placeRobot", () => {
+  const mockTabletopBoundary: XYCoordinates = [100, 200];
+
+  it("returns a robot state when placed", () => {
+    const robotState = null;
+
+    const mockRobotPlaceAction: PlaceCommandAction = {
+      type: Command.Place,
+      data: {
+        coordinates: [4, 5],
+        direction: Direction.North,
+      },
+    };
+
+    const newRobotState: RobotState = {
+      coordinates: [4, 5],
+      direction: Direction.North,
+    };
+
+    expect(
+      placeRobot(robotState, mockRobotPlaceAction, mockTabletopBoundary)
+    ).toEqual(newRobotState);
+
+    const mockRobotPlaceAction2: PlaceCommandAction = {
+      type: Command.Place,
+      data: {
+        coordinates: [1, 2],
+        direction: Direction.East,
+      },
+    };
+
+    const newRobotState2: RobotState = {
+      coordinates: [1, 2],
+      direction: Direction.East,
+    };
+
+    expect(
+      placeRobot(newRobotState, mockRobotPlaceAction2, mockTabletopBoundary)
+    ).toEqual(newRobotState2);
+  });
+
+  it("throws an error if robot is placed outside tabletop", () => {
+    const robotState = null;
+
+    const mockRobotPlaceAction: PlaceCommandAction = {
+      type: Command.Place,
+      data: {
+        coordinates: [200, 5],
+        direction: Direction.North,
+      },
+    };
+
+    expect(() => {
+      placeRobot(robotState, mockRobotPlaceAction, mockTabletopBoundary);
+    }).toThrow(getOutsideTabletopErrorMessage(mockTabletopBoundary));
+  });
+});

--- a/src/robot/actions/__tests__/report-robot.test.ts
+++ b/src/robot/actions/__tests__/report-robot.test.ts
@@ -1,0 +1,27 @@
+import { robotNotPlacedErrorMessage } from "../../../messages";
+import { Direction, RobotState } from "../../../types";
+import { reportRobot } from "../report-robot";
+
+describe("reportRobot", () => {
+  console.log = jest.fn();
+
+  it("logs robot coordinates and direction", () => {
+    const mockRobotState: RobotState = {
+      coordinates: [31, 42],
+      direction: Direction.West,
+    };
+
+    reportRobot(mockRobotState);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("31"));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("42"));
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining(Direction.West)
+    );
+  });
+
+  it("throws an error if robot is uninitialized (not placed on tabletop)", () => {
+    expect(() => {
+      reportRobot(null);
+    }).toThrow(robotNotPlacedErrorMessage);
+  });
+});

--- a/src/robot/actions/__tests__/turn-robot.test.ts
+++ b/src/robot/actions/__tests__/turn-robot.test.ts
@@ -1,0 +1,46 @@
+import {
+  Command,
+  Direction,
+  RobotState,
+  TurnCommandAction,
+} from "../../../types";
+import { turnRobot } from "../turn-robot";
+
+describe("turnRobot", () => {
+  const mockRobotState: RobotState = {
+    coordinates: [31, 42],
+    direction: Direction.North,
+  };
+
+  const mockLeftAction: TurnCommandAction = {
+    type: Command.Left,
+  };
+
+  const mockRightAction: TurnCommandAction = {
+    type: Command.Right,
+  };
+
+  it("returns new robot state after rotation", () => {
+    expect(turnRobot(mockRobotState, mockLeftAction)).toEqual({
+      ...mockRobotState,
+      direction: Direction.West,
+    });
+
+    expect(turnRobot(mockRobotState, mockRightAction)).toEqual({
+      ...mockRobotState,
+      direction: Direction.East,
+    });
+  });
+
+  it("allows rotation amount value to be modified", () => {
+    expect(turnRobot(mockRobotState, mockLeftAction, 2)).toEqual({
+      ...mockRobotState,
+      direction: Direction.South,
+    });
+
+    expect(turnRobot(mockRobotState, mockRightAction, 3)).toEqual({
+      ...mockRobotState,
+      direction: Direction.West,
+    });
+  });
+});

--- a/src/robot/actions/index.ts
+++ b/src/robot/actions/index.ts
@@ -1,1 +1,2 @@
 export { placeRobot } from "./place-robot";
+export { turnRobot } from "./turn-robot";

--- a/src/robot/actions/index.ts
+++ b/src/robot/actions/index.ts
@@ -1,2 +1,3 @@
+export { moveRobot } from "./move-robot";
 export { placeRobot } from "./place-robot";
 export { turnRobot } from "./turn-robot";

--- a/src/robot/actions/index.ts
+++ b/src/robot/actions/index.ts
@@ -1,0 +1,1 @@
+export { placeRobot } from "./place-robot";

--- a/src/robot/actions/index.ts
+++ b/src/robot/actions/index.ts
@@ -1,3 +1,4 @@
 export { moveRobot } from "./move-robot";
 export { placeRobot } from "./place-robot";
+export { reportRobot } from "./report-robot";
 export { turnRobot } from "./turn-robot";

--- a/src/robot/actions/move-robot.ts
+++ b/src/robot/actions/move-robot.ts
@@ -1,0 +1,55 @@
+import {
+  getOutsideTabletopErrorMessage,
+  robotNotPlacedErrorMessage,
+} from "../../messages";
+import { Direction, RobotState, XYCoordinates } from "../../types";
+import {
+  defaultRobotStepsPerMove,
+  defaultTabletopBoundary,
+} from "../../variables";
+import { isOutsideBoundary } from "../utils";
+
+/**
+ * @param state - current robot state which includes coordinates & direction
+ * @param tabletopBoundary - throws error if move would cause robot to move
+ * outside the tabletop boundary
+ * @param stepsPerMove - amount of steps taken in the robot's direction
+ * @returns new robot state with new coordinates after moving in the direction
+ * the robot was facing
+ */
+export const moveRobot = (
+  state: RobotState | null,
+  tabletopBoundary: XYCoordinates = defaultTabletopBoundary,
+  stepsPerMove: number = defaultRobotStepsPerMove
+): RobotState | never => {
+  if (!state) throw Error(robotNotPlacedErrorMessage);
+
+  const { coordinates, direction } = state;
+  const [x, y] = coordinates;
+
+  let newCoordinates: XYCoordinates;
+
+  switch (direction) {
+    case Direction.North: {
+      newCoordinates = [x, y + stepsPerMove];
+      break;
+    }
+    case Direction.South: {
+      newCoordinates = [x, y - stepsPerMove];
+      break;
+    }
+    case Direction.East: {
+      newCoordinates = [x + stepsPerMove, y];
+      break;
+    }
+    case Direction.West: {
+      newCoordinates = [x - stepsPerMove, y];
+    }
+  }
+
+  if (isOutsideBoundary(newCoordinates, tabletopBoundary)) {
+    throw Error(getOutsideTabletopErrorMessage(tabletopBoundary));
+  }
+
+  return { ...state, coordinates: newCoordinates };
+};

--- a/src/robot/actions/place-robot.ts
+++ b/src/robot/actions/place-robot.ts
@@ -1,0 +1,31 @@
+import {
+  getOutsideTabletopErrorMessage,
+  invalidDirectionErrorMessage,
+} from "../../messages";
+import { PlaceCommandAction, RobotState, XYCoordinates } from "../../types";
+import { isOutsideBoundary, isValidDirection } from "../utils";
+
+/**
+ * Places robot on the tabletop
+ *
+ * @param state - current robot state
+ * @param placeCommandAction - command action object with action type of
+ * "PLACE" & data object
+ * @param placeCommandAction.data - contains coordinates & direction to place
+ * robot
+ * @param tabletopBoundary - throws error if placed outside the tabletop
+ * boundary
+ * @returns new robot state after placing robot
+ */
+export const placeRobot = (
+  state: RobotState | null,
+  { data }: PlaceCommandAction,
+  tabletopBoundary: XYCoordinates
+): RobotState | never => {
+  const { coordinates, direction } = data;
+
+  if (isOutsideBoundary(coordinates))
+    throw Error(getOutsideTabletopErrorMessage(tabletopBoundary));
+  if (!isValidDirection(direction)) throw Error(invalidDirectionErrorMessage);
+  return { ...state, ...data };
+};

--- a/src/robot/actions/report-robot.ts
+++ b/src/robot/actions/report-robot.ts
@@ -1,0 +1,10 @@
+import {
+  getReportRobotMessage,
+  robotNotPlacedErrorMessage,
+} from "../../messages";
+import { RobotState } from "../../types";
+
+export const reportRobot = (robotState: RobotState | null): void | never => {
+  if (!robotState) throw Error(robotNotPlacedErrorMessage);
+  console.log(getReportRobotMessage(robotState));
+};

--- a/src/robot/actions/turn-robot.ts
+++ b/src/robot/actions/turn-robot.ts
@@ -1,0 +1,35 @@
+import { robotNotPlacedErrorMessage } from "../../messages";
+import { Command, RobotState, TurnCommandAction } from "../../types";
+import { clockwiseDirections } from "../../variables";
+import { getCircularArrayIndex } from "../utils";
+
+/**
+ * @param state - robot state (null if not placed on tabletop)
+ * @param action - turn command action object with action.type of
+ * "LEFT" or "RIGHT"
+ * @param rotationAmount - number of indexes to jump per rotation in the
+ * clockwiseDirections array.
+ * @returns new robot state with new direction
+ */
+export const turnRobot = (
+  state: RobotState | null,
+  action: TurnCommandAction,
+  rotationAmount = 1
+): RobotState | never => {
+  if (!state) throw Error(robotNotPlacedErrorMessage);
+
+  const currentDirectionIndex = clockwiseDirections.indexOf(state.direction);
+
+  const increment =
+    action.type === Command.Right ? rotationAmount : -rotationAmount;
+
+  const newDirectionIndex = getCircularArrayIndex(
+    clockwiseDirections,
+    currentDirectionIndex,
+    increment
+  );
+
+  const newDirection = clockwiseDirections[newDirectionIndex];
+
+  return { ...state, direction: newDirection };
+};

--- a/src/robot/command-robot.ts
+++ b/src/robot/command-robot.ts
@@ -1,0 +1,33 @@
+import { Command, CommandAction, RobotState, XYCoordinates } from "../types";
+import { moveRobot, placeRobot, reportRobot, turnRobot } from "./actions";
+
+/**
+ * @param state - initial robot state. Is null if robot is not placed on tabletop.
+ * @param action - action on the robot. Only the "REPORT" action type does not
+ * affect robot state.
+ * @param tabletopBoundary - if a place or move action type will move the robot
+ * outside the tabletop boundary, the action will be ignored.
+ * @returns new robot state after action is applied
+ */
+export const commandRobot = (
+  state: RobotState | null,
+  action: CommandAction,
+  tabletopBoundary: XYCoordinates
+): RobotState | null | never => {
+  switch (action.type) {
+    case Command.Place: {
+      return placeRobot(state, action, tabletopBoundary);
+    }
+    case Command.Left:
+    case Command.Right: {
+      return turnRobot(state, action);
+    }
+    case Command.Move: {
+      return moveRobot(state, tabletopBoundary);
+    }
+    case Command.Report: {
+      reportRobot(state);
+      return state;
+    }
+  }
+};

--- a/src/robot/utils/__tests__/get-circular-array-index.test.ts
+++ b/src/robot/utils/__tests__/get-circular-array-index.test.ts
@@ -1,0 +1,61 @@
+import { getCircularArrayIndex } from "../get-circular-array-index";
+
+describe("getCircularArrayIndex", () => {
+  const mockCircularArray = ["north", "east", "south", "west"];
+  const getIndex = (arrayValue: string) =>
+    mockCircularArray.indexOf(arrayValue);
+
+  it("correctly increments or decrements in the array when no loops are necessary", () => {
+    const eastIndex = getIndex("east");
+    const increment = 2;
+    const expectedIncrementIndex = getIndex("west");
+
+    expect(
+      getCircularArrayIndex(mockCircularArray, eastIndex, increment)
+    ).toEqual(expectedIncrementIndex);
+
+    const decrement = -1;
+    const expectedDecrementIndex = getIndex("north");
+
+    expect(
+      getCircularArrayIndex(mockCircularArray, eastIndex, decrement)
+    ).toEqual(expectedDecrementIndex);
+  });
+
+  it("correctly loops to the start of the array when incrementing beyond end of array", () => {
+    const eastIndex = getIndex("east");
+    const increment = 5;
+    const expectedIndex = getIndex("south");
+
+    expect(
+      getCircularArrayIndex(mockCircularArray, eastIndex, increment)
+    ).toEqual(expectedIndex);
+  });
+
+  it("correctly loops to the end of the array when decrementing beyond start of array", () => {
+    const eastIndex = getIndex("east");
+    const increment = -2;
+    const expectedIndex = getIndex("west");
+
+    expect(
+      getCircularArrayIndex(mockCircularArray, eastIndex, increment)
+    ).toEqual(expectedIndex);
+  });
+
+  it("correctly cycles over array when the increment or decrement is multiple times larger than the array length", () => {
+    const eastIndex = getIndex("east");
+    const increment = 13;
+    const expectedIncrementIndex = getIndex("south");
+
+    expect(
+      getCircularArrayIndex(mockCircularArray, eastIndex, increment)
+    ).toEqual(expectedIncrementIndex);
+
+    const decrement = -15;
+    const expectedDecrementIndex = getIndex("south");
+
+    expect(
+      getCircularArrayIndex(mockCircularArray, eastIndex, decrement)
+    ).toEqual(expectedDecrementIndex);
+  });
+});

--- a/src/robot/utils/__tests__/is-outside-boundary.test.ts
+++ b/src/robot/utils/__tests__/is-outside-boundary.test.ts
@@ -1,0 +1,17 @@
+import { isOutsideBoundary } from "../is-outside-boundary";
+
+describe("isOutsideBoundary", () => {
+  const mockBoundary2D = [5, 6];
+  const mockBoundary3D = [7, 8, 9];
+
+  it("correctly identifies that coordinates are outside a boundary", () => {
+    expect(isOutsideBoundary([4, 8], mockBoundary2D)).toEqual(true);
+    expect(isOutsideBoundary([6, 3], mockBoundary2D)).toEqual(true);
+    expect(isOutsideBoundary([1, 2, 99], mockBoundary3D)).toEqual(true);
+  });
+
+  it("correctly identifies that coordinates are inside a boundary", () => {
+    expect(isOutsideBoundary([4, 3], mockBoundary2D)).toEqual(false);
+    expect(isOutsideBoundary([7, 8, 3], mockBoundary3D)).toEqual(false);
+  });
+});

--- a/src/robot/utils/__tests__/is-valid-direction.test.ts
+++ b/src/robot/utils/__tests__/is-valid-direction.test.ts
@@ -1,0 +1,19 @@
+import { isValidDirection } from "../is-valid-direction";
+
+jest.mock("../../../variables", () => ({
+  clockwiseDirections: ["east", "south", "west", "north"],
+}));
+
+describe("isValidDirection", () => {
+  it("correctly identifies that a direction is a value in the clockwiseDirections array", () => {
+    expect(isValidDirection("north")).toEqual(true);
+    expect(isValidDirection("south")).toEqual(true);
+    expect(isValidDirection("east")).toEqual(true);
+    expect(isValidDirection("west")).toEqual(true);
+  });
+
+  it("correctly identifies that a direction is not a value in the clockwiseDirections array", () => {
+    expect(isValidDirection("northWest")).toEqual(false);
+    expect(isValidDirection("NORTH")).toEqual(false);
+  });
+});

--- a/src/robot/utils/get-circular-array-index.ts
+++ b/src/robot/utils/get-circular-array-index.ts
@@ -1,0 +1,31 @@
+/**
+ * Find the index of a circular array based on how many increments or
+ * decrements are taken from a given index position.
+ *
+ * This utility is used in this app to cycle the direction of the robot
+ * when rotating left or right.
+ *
+ * @param array the circular array to cycle through
+ * @param currentIndex the current position to start incrementing from
+ * @param increment increment of 1 represents +1 index position of the
+ * currentIndex. -1 decrements 1 step back from the currentIndex.
+ */
+export const getCircularArrayIndex = (
+  array: unknown[],
+  currentIndex: number,
+  increment: number
+): number => {
+  /* increments after removing full cycles around the array */
+  const effectiveIncrement = increment % array.length;
+
+  const newRelativeIndex = currentIndex + effectiveIncrement;
+
+  /**
+   * Need to offset decrements beyond the 0th index or increments beyond
+   * the last index (e.g. looping around the array) by adding or subtracting
+   * the array length.
+   */
+  if (newRelativeIndex < 0) return newRelativeIndex + array.length;
+  if (newRelativeIndex >= array.length) return newRelativeIndex - array.length;
+  return newRelativeIndex;
+};

--- a/src/robot/utils/index.ts
+++ b/src/robot/utils/index.ts
@@ -1,0 +1,2 @@
+export { isOutsideBoundary } from "./is-outside-boundary";
+export { isValidDirection } from "./is-valid-direction";

--- a/src/robot/utils/index.ts
+++ b/src/robot/utils/index.ts
@@ -1,2 +1,3 @@
+export { getCircularArrayIndex } from "./get-circular-array-index";
 export { isOutsideBoundary } from "./is-outside-boundary";
 export { isValidDirection } from "./is-valid-direction";

--- a/src/robot/utils/is-outside-boundary.ts
+++ b/src/robot/utils/is-outside-boundary.ts
@@ -1,0 +1,9 @@
+import { defaultTabletopBoundary } from "../../variables";
+
+export const isOutsideBoundary = (
+  coordinates: number[],
+  boundary: number[] = defaultTabletopBoundary
+): boolean =>
+  coordinates.some(
+    (coordinate, index) => coordinate < 0 || coordinate > boundary[index]
+  );

--- a/src/robot/utils/is-valid-direction.ts
+++ b/src/robot/utils/is-valid-direction.ts
@@ -1,0 +1,4 @@
+import { clockwiseDirections } from "../../variables";
+
+export const isValidDirection = (input: string): boolean =>
+  clockwiseDirections.some((direction) => direction === input);

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,15 @@ export type RobotState = {
 };
 
 /**
+ * When the robot is not yet placed on the tabletop when the app is initialized,
+ * its value is null.
+ */
+export type AppState = {
+  robot: RobotState | null;
+  tabletopBoundary: XYCoordinates;
+};
+
+/**
  * Action types that are dispatched to change the app's robot state.
  */
 export type Action<Type = string> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,31 @@ export enum Direction {
   West = "WEST",
 }
 
+export enum Command {
+  Left = "LEFT",
+  Right = "RIGHT",
+  Place = "PLACE",
+  Move = "MOVE",
+  Report = "REPORT",
+}
+
 export type RobotState = {
   coordinates: XYCoordinates;
   direction: Direction;
+};
+
+/**
+ * Action types that are dispatched to change the app's robot state.
+ */
+export type Action<Type = string> = {
+  type: Type;
+  data?: { [key: string]: unknown };
+};
+
+/**
+ * Place action accepts parameters (coordinates and direction of the robot) in
+ * the data field.
+ */
+export type PlaceCommandAction = Action<Command.Place> & {
+  data: RobotState;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,13 @@
+export type XYCoordinates = [number, number];
+
+export enum Direction {
+  North = "NORTH",
+  South = "SOUTH",
+  East = "EAST",
+  West = "WEST",
+}
+
+export type RobotState = {
+  coordinates: XYCoordinates;
+  direction: Direction;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,16 @@ export type PlaceCommandAction = Action<Command.Place> & {
 export type TurnCommandAction = Action<
   Extract<Command, Command.Left | Command.Right>
 >;
+
+export type OtherCommandAction = Action<
+  Extract<Command, Command.Move | Command.Report>
+>;
+
+/**
+ * Stricter type than a generic Action.
+ * CommandAction["type"] must be one of the Command enum values
+ */
+export type CommandAction =
+  | PlaceCommandAction
+  | TurnCommandAction
+  | OtherCommandAction;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,3 +35,7 @@ export type Action<Type = string> = {
 export type PlaceCommandAction = Action<Command.Place> & {
   data: RobotState;
 };
+
+export type TurnCommandAction = Action<
+  Extract<Command, Command.Left | Command.Right>
+>;

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,14 @@
+import { Direction, XYCoordinates } from "./types";
+
+export const defaultTabletopBoundary: XYCoordinates = [5, 5];
+export const defaultRobotStepsPerMove = 1;
+
+/**
+ * Directions in clockwise order
+ */
+export const clockwiseDirections: Direction[] = [
+  Direction.North,
+  Direction.East,
+  Direction.South,
+  Direction.West,
+];


### PR DESCRIPTION
### What this PR does
Creates a functional toy robot CLI app with tests.

- add `placeRobot`, `turnRobot`, `moveRobot` & `moveRobot` functions handled by `commandRobot` to execute robot logic
- add `parseCommand` function to convert input strings from terminal into actions handled by `commandRobot`
- add cli startup script to run the app and receive input & display errors