### PR TITLE
Fix remove build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
-
+build/
 .eslintcache

--- a/build/index.js
+++ b/build/index.js
@@ -1,3 +1,0 @@
-"use strict";
-console.log('Hello World');
-//# sourceMappingURL=index.js.map

--- a/build/index.js.map
+++ b/build/index.js.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";AACA,OAAO,CAAC,GAAG,CAAC,aAAa,CAAC,CAAC"}


### PR DESCRIPTION
### What this PR does
- remove build folder left unintentionally due to missing `build/` in .gitignore